### PR TITLE
Use SPT Path over ../../ if it's available

### DIFF
--- a/HeadshotDarkness.csproj
+++ b/HeadshotDarkness.csproj
@@ -190,7 +190,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <None Include="HeadshotDarkness.csproj.user" />
+      <Content Include="HeadshotDarkness.csproj.user" />
     </ItemGroup>
 
     <Target Name="CopyToSPT" AfterTargets="AfterBuild" Condition="'$(SPTPath)' != ''">

--- a/HeadshotDarkness.csproj
+++ b/HeadshotDarkness.csproj
@@ -190,7 +190,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Content Include="HeadshotDarkness.csproj.user" />
+        <Content Include="HeadshotDarkness.csproj.user" />
     </ItemGroup>
 
     <Target Name="CopyToSPT" AfterTargets="AfterBuild" Condition="'$(SPTPath)' != ''">

--- a/HeadshotDarkness.csproj
+++ b/HeadshotDarkness.csproj
@@ -18,8 +18,66 @@
     <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
         <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all"/>
     </ItemGroup>
+    
+    <ItemGroup Condition="'$(SPTPath)' != ''">
+        <Reference Include="Assembly-CSharp">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\Assembly-CSharp.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="BepInEx">
+            <HintPath>$(SPTPath)\BepInEx\core\BepInEx.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Comfort">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\Comfort.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Newtonsoft.Json">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\Newtonsoft.Json.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="spt-custom">
+            <HintPath>$(SPTPath)\BepInEx\plugins\spt\spt-custom.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="spt-reflection">
+            <HintPath>$(SPTPath)\BepInEx\plugins\spt\spt-reflection.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="Unity.TextMeshPro">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+        </Reference>
+        <Reference Include="UnityEngine">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\UnityEngine.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.AudioModule">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.CoreModule">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.JSONSerializeModule">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\UnityEngine.JSONSerializeModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.TextRenderingModule">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.UI">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\UnityEngine.UI.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="UnityEngine.UIModule">
+            <HintPath>$(SPTPath)\EscapeFromTarkov_Data\Managed\UnityEngine.UIModule.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+    </ItemGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(SPTPath)' == ''">
         <Reference Include="Assembly-CSharp">
             <HintPath>..\..\EscapeFromTarkov_Data\Managed\Assembly-CSharp.dll</HintPath>
             <Private>False</Private>
@@ -132,7 +190,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Content Include="HeadshotDarkness.csproj.user"/>
+      <None Include="HeadshotDarkness.csproj.user" />
     </ItemGroup>
 
     <Target Name="CopyToSPT" AfterTargets="AfterBuild" Condition="'$(SPTPath)' != ''">


### PR DESCRIPTION
Saw that you were using a csproj.user file that contained the spt path, so i added a little section that uses the spt path when resolving the dependencies, and if it doesn't, just stick with ../../